### PR TITLE
pc-thinclient modified to support external dhcp server

### DIFF
--- a/src-sh/pc-thinclient/pc-thinclient
+++ b/src-sh/pc-thinclient/pc-thinclient
@@ -237,20 +237,6 @@ inetd_enable=\"YES\"" >> /etc/rc.conf
 portmap : $netid/$netmaskid : allow\\
 rpcbind : ALL : deny|" /etc/hosts.allow
 
-	# Add a bulk of IPs to /etc/hosts this fixes bugs with RPC timeouts
-	# when mounting NFS
-	grep -q 'thinclient100' /etc/hosts
-	if [ $? -ne 0 ] ; then
-		i="100"
-		while
-		z="1"
-		do
-			if [ "${i}" = "200" ]; then break; fi
-			echo "192.168.2.${i}  thinclient${i}" >>/etc/hosts
-			i="`expr ${i} + 1`"
-		done
-	fi
-
 	# Start the services
 	cmds="/etc/rc.d/nfsd /etc/rc.d/inetd"
 	for _sC in $cmds


### PR DESCRIPTION
Here is the modified pc-thinclient which includes support for using an external dhcp server.  It does not yet contain the recent updates to use the PCBSD CDN.  
