### PR TITLE
In FreeBSD, set_rcvar() was removed here:

### DIFF
--- a/src-qt4/pc-sounddetect/rc.d/pc-sounddetect
+++ b/src-qt4/pc-sounddetect/rc.d/pc-sounddetect
@@ -7,7 +7,7 @@
 . /etc/rc.subr
 
 name="snddetect"
-rcvar=`set_rcvar`
+rcvar=snddetect_enable
 
 stop_cmd="snddetect_stop"
 start_cmd="snddetect_start"

--- a/src-sh/warden/scripts/rc.d/wardenrc
+++ b/src-sh/warden/scripts/rc.d/wardenrc
@@ -7,7 +7,7 @@
 . /etc/rc.subr
 
 name="warden"
-rcvar=`set_rcvar`
+rcvar="warden_enable"
 
 stop_cmd="warden_stop"
 start_cmd="warden_start"


### PR DESCRIPTION
```
|------------------------------------------------------------------------
|r230103 | dougb | 2012-01-14 00:59:02 -0800 (Sat, 14 Jan 2012) | 6 lines
|
|Now that its callers have been udpated, remove set_rcvar().
|
|The concept of set_rcvar() was nice in theory, but the forks
|it creates are a drag on the startup process, which is especially
|noticeable on slower systems, such as embedded ones.
|
|------------------------------------------------------------------------
```

Perform similar fixes to the PC-BSD startup scripts to accomodate this change
in FreeBSD 10:

```
|------------------------------------------------------------------------
|r230099 | dougb | 2012-01-13 18:18:41 -0800 (Fri, 13 Jan 2012) | 14 lines
|
|Prepare for the removal of set_rcvar() by changing the rcvar=
|assignments to the literal values it would have returned.
|
|The concept of set_rcvar() was nice in theory, but the forks
|it creates are a drag on the startup process, which is especially
|noticeable on slower systems, such as embedded ones.
|
|During the discussion on freebsd-rc@ a preference was expressed for
|using ${name}_enable instead of the literal values. However the
|code portability concept doesn't really apply since there are so
|many other places where the literal name has to be searched for
|and replaced. Also, using the literal value is also a tiny bit
|faster than dereferencing the variables, and every little bit helps.
|
|------------------------------------------------------------------------
```
