### PR TITLE
Changed "Le francais" to "Francais" in the language selection screen during first boot and during installation

### DIFF
--- a/overlays/install-overlay/usr/share/pc-sysinstall/conf/avail-langs
+++ b/overlays/install-overlay/usr/share/pc-sysinstall/conf/avail-langs
@@ -18,7 +18,7 @@ en_ZA English_(South Africa)
 en_GB English_(UK)
 et Eesti Keel
 fi Suomi
-fr Le français
+fr Français
 fr_CA Français canadien
 fur Furlan
 gl ɡəˈlɪʃən

--- a/src-sh/pc-sysinstall/conf/avail-langs
+++ b/src-sh/pc-sysinstall/conf/avail-langs
@@ -18,7 +18,7 @@ en_ZA English_(South Africa)
 en_GB English_(UK)
 et Eesti Keel
 fi Suomi
-fr Le français
+fr Français
 fr_CA Français canadien
 fur Furlan
 gl ɡəˈlɪʃən


### PR DESCRIPTION
This fixes a little typo. In the list, we should see "Français" instead of "Le français" which is equivalent to "The english".
