### PR TITLE
Added in \[ and \] as they are valid for passwords.

### DIFF
--- a/src-qt4/pc-usermanager/usermanagerback.cpp
+++ b/src-qt4/pc-usermanager/usermanagerback.cpp
@@ -38,7 +38,7 @@ void UserManagerBackend::programInit() {
     fullnameRegExp.setPattern("([:!@])+");
     homeLocRegExp.setPattern("^(/usr)?/home/?");
     usernameRegExp.setPattern("([a-z]*[A-Z]*[0-9]*[_]*)+");
-    passwordRegExp.setPattern("([a-z]*[A-Z]*[0-9]*[!\"$%^&*()_+=#'`@~:?<>|{}\\-.,]*)+");
+    passwordRegExp.setPattern("([a-z]*[A-Z]*[0-9]*[!\"$%^&*()_+=#'`@~:?<>|{}\\x5b;\\-.,\\x5d]*)+");
     groupnameRegExp.setPattern("([a-z]*[A-Z]*[0-9]*[_]*)+");
 }
 


### PR DESCRIPTION
The square brackets are all that I could find, which required weird escaping for QRegExp. In qt5, QRegularExpression is apparently faster.
