### PR TITLE
Use route(8) instead of netstat(1) to get default interface

### DIFF
--- a/src-sh/warden/scripts/backend/functions.sh
+++ b/src-sh/warden/scripts/backend/functions.sh
@@ -522,7 +522,7 @@ get_default_route()
 
 get_default_interface()
 {
-   netstat -f inet -nrW | grep '^default' | awk '{ print $7 }'
+   route get default | grep 'interface:' | awk '{ print $2 }'
 }
 
 get_bridge_interfaces()


### PR DESCRIPTION
netstat(1) may truncate the interface name if it is long enough, e.g.
vlan100 -> vlan10
