### PR TITLE
Update xdg-open

### DIFF
--- a/src-sh/pc-extractoverlay/ports-overlay/usr/local/bin/xdg-open
+++ b/src-sh/pc-extractoverlay/ports-overlay/usr/local/bin/xdg-open
@@ -555,7 +555,7 @@ fi
 if [ x"$BROWSER" = x"" ]; then
     BROWSER=links2:links:lynx:w3m
     if [ -n "$DISPLAY" ]; then
-        BROWSER=firefox:mozilla:epiphany:konqueror:chromium-browser:google-chrome:$BROWSER
+        BROWSER=firefox:mozilla:epiphany:konqueror:chrome:chromium-browser:google-chrome:$BROWSER
     fi
 fi
 


### PR DESCRIPTION
If chromium is Installed in FreeBSD (form ports www/chromium) the binary name is 'chrome'
