### PR TITLE
Use missing instead of all-depends-list

### DIFF
--- a/src-sh/pbi-manager/pbi-manager
+++ b/src-sh/pbi-manager/pbi-manager
@@ -7728,7 +7728,7 @@ do_port_build()
   fi
 
   # Parse the pkg deps 
-  for _port in `make -C $_lPort PORTSDIR=${PORTSDIR} all-depends-list|sed 's,^${PORTSDIR}/,,g'`
+  for _port in `make -C $_lPort PORTSDIR=${PORTSDIR} missing`
   do
     if [ -z "${_port}" ] ; then continue ; fi
 


### PR DESCRIPTION
Use ports "make missing", that lists only missing dependencies instead of the complete list. Since make missing output doesn't show PORTSDIR, sed is useless
