### PR TITLE
Silence attempt to mount /usr/local/share/font-* when it doesn't exist

### DIFF
--- a/src-sh/pbi-manager/pbime/pbimount
+++ b/src-sh/pbi-manager/pbime/pbimount
@@ -129,7 +129,7 @@ mount_dirs() {
    fi
 
    # Support for some font packages(example: japanese/font-vlgothic)
-   for fontdir in /usr/local/share/font-*
+   for fontdir in `ls -1 /usr/local/share/font-* 2>/dev/null`
    do
       subdir=`basename $fontdir`
       if [ ! -d "${pDir}/virtbase/usr/local/share/$subdir" ]; then


### PR DESCRIPTION
When there are no directories that match the wildcard "/usr/local/share/font-*", it's not expanded and generate errors like this one:

```
.mount_nullfs: /usr/local/share/font-*: No such file or directory
```

This change fix it because ls will return nothing in this case.
