### PR TITLE
Fix own, group and mode definitions, s/PROG/BIN/ according bsd.prog.mk

### DIFF
--- a/src-sh/pc-adctl/pc-krbconf/Makefile
+++ b/src-sh/pc-adctl/pc-krbconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-krbconf

--- a/src-sh/pc-adctl/pc-ldapconf/Makefile
+++ b/src-sh/pc-adctl/pc-ldapconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-ldapconf

--- a/src-sh/pc-adctl/pc-nssconf/Makefile
+++ b/src-sh/pc-adctl/pc-nssconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-nssconf

--- a/src-sh/pc-adctl/pc-nssldapconf/Makefile
+++ b/src-sh/pc-adctl/pc-nssldapconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-nssldapconf

--- a/src-sh/pc-adctl/pc-pamconf/Makefile
+++ b/src-sh/pc-adctl/pc-pamconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-pamconf

--- a/src-sh/pc-adctl/pc-sambaconf/Makefile
+++ b/src-sh/pc-adctl/pc-sambaconf/Makefile
@@ -6,9 +6,9 @@
 
 PREFIX?= /usr/local
 MAN=
-PROGOWN=	root
-PROGGRP=	wheel
-PROGMODE=	0555
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
 DESTDIR=	$(PREFIX)/bin
 
 PROG=	pc-sambaconf


### PR DESCRIPTION
The correct names are BINOWN, BINGRP and BINMODE as you can see on /usr/share/mk/bsd.prog.mk. Normally I'd suggest to just remove them since they are using the default values, but, keeping it there will help to fix port stage with non-root.
