### PR TITLE
fix potential buffer overflow in SYSTEM::hostname

### DIFF
--- a/lumina/lumina-desktop/Globals.h
+++ b/lumina/lumina-desktop/Globals.h
@@ -21,7 +21,7 @@ public:
 	static QString user(){ return QString::fromLocal8Bit(getlogin()); }
 	//Current Hostname
 	static QString hostname(){ 
-	  char name[64];
+	  char name[BUFSIZ];
 	  int count = gethostname(name,sizeof(name));
 	  if (count < 0) {
 	    return QString::null;


### PR DESCRIPTION
gethostname() may cause an error or it might need more space than any given static buffer provides. In both cases the data in the buffer might not be null terminated!

Also String() uses fromAscii(). While I guess this should be ok for host names I think it is always better to use fromLocal8Bit(). I think the user name might not be 7-bit ASCII.

**Note:** I wrote this from head in the online editor on GitHub. So I haven't even tested if it compiles. I just wanted to tell you about that possible problem.
