### PR TITLE
Fix logname crash

### DIFF
--- a/src-sh/pbi-manager/pbi_preload/pbi_preload.c
+++ b/src-sh/pbi-manager/pbi_preload/pbi_preload.c
@@ -97,7 +97,7 @@ void first_init()
    strcat(hints32, pbiname);
 
    // Get the process username
-   strcpy(username, getenv("LOGNAME"));
+   strcpy(username, getlogin());
    strcpy(hashdir, "/usr/pbi/.hashdir-");
    strcat(hashdir, username);
 


### PR DESCRIPTION
I sent it direct to the branch since the code on master changed a lot and seems to do not have pbi_preload.so anymore.
