### PR TITLE
Bridge is destroyed when it still contains members

### DIFF
--- a/src-sh/warden/scripts/backend/functions.sh
+++ b/src-sh/warden/scripts/backend/functions.sh
@@ -642,7 +642,7 @@ jail_interfaces_down()
       ifconfig ${_epaira} down
       ifconfig ${_epaira} destroy
       _count=`ifconfig ${_bridgeif} | grep member | awk '{ print $2 }' | wc -l`
-      if [ "${_count}" -le "1" ] ; then
+      if [ "${_count}" -lt "1" ] ; then
          ifconfig ${_bridgeif} destroy
       fi
    fi


### PR DESCRIPTION
Noticed this issue on my FreeBSD system, running warden from sysutils/pcbsd-utils. The IP for my host is on bridge0 and I noticed that when I stopped the last warden jail my bridge0 would be deleted, but I still need it and it has my physical interface as a member so the member count is equal to 1 after the epair device is deleted.
