### PR TITLE
lpreserver listcron - splitting of snap/scrub output

### DIFF
--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -169,6 +169,44 @@ enable_cron_scrub()
    echo -e "$cLine\troot    ${cronscript} $1" >> /etc/crontab
 }
 
+list_cron_snap()
+{
+echo "Datasets scheduled for snapshots:"
+echo "---------------------------------"
+for i in `grep "${PROGDIR}/backend/runsnap.sh" /etc/crontab | awk '{print $8}'`
+do
+   min=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $1}'`
+   hour=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $2}'`
+   count=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $9}'`
+   time="Min: $min Hour: $hour";
+   if [ "$min" = "0" -a "$hour" != '*' ] ; then time="daily@$hour" ; fi
+   if [ "$min" = "0" -a "$hour" = '*' ] ; then time="hourly" ; fi
+   if [ "$min" = "0,30" ] ; then time="30min" ; fi
+   if [ "$min" = '*/10' ] ; then time="10min" ; fi
+   if [ "$min" = '*/5' ] ; then time="5min" ; fi
+   if [ "$min" = '*/5' -a "$count" = "auto" ] ; then time="Automatic" ; fi
+   echo "$i - $time - total: $count"
+   echo ""
+done
+}
+
+list_cron_scrub()
+{
+echo "Pools scheduled for scrub:"
+echo "---------------------------------"
+for i in `grep "${PROGDIR}/backend/runscrub.sh" /etc/crontab | awk '{print $8}'`
+do
+   hour=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $2}'`
+   day_week=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $5}'`
+   day_month=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $3}'`
+   if [ "$hour" != '*' -a "$day_week" = '*' -a "$day_month" = '*' ] ; then time="daily @ hour $hour" ; fi
+   if [ "$day_week" != '*' ] ; then time="weekly @ day $day_week @ hour $hour" ; fi
+   if [ "$day_month" != '*' ] ; then time="monthly @ day $day_month @ hour $hour" ; fi
+   echo "$i - $time"
+   echo ""
+done
+}
+
 enable_watcher()
 {
    cronscript="${PROGDIR}/backend/zfsmon.sh"

--- a/src-sh/lpreserver/backend/zfslistcron.sh
+++ b/src-sh/lpreserver/backend/zfslistcron.sh
@@ -11,34 +11,18 @@ PROGDIR="/usr/local/share/lpreserver"
 . /usr/local/share/pcbsd/scripts/functions.sh
 . ${PROGDIR}/backend/functions.sh
 
-echo "Datasets scheduled for snapshots:"
-echo "---------------------------------"
-for i in `grep "${PROGDIR}/backend/runsnap.sh" /etc/crontab | awk '{print $8}'`
-do
-   min=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $1}'`
-   hour=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $2}'`
-   count=`grep "${PROGDIR}/backend/runsnap.sh ${i}" /etc/crontab | awk '{print $9}'`
-   time="Min: $min Hour: $hour";
-   if [ "$min" = "0" -a "$hour" != '*' ] ; then time="daily@$hour" ; fi
-   if [ "$min" = "0" -a "$hour" = '*' ] ; then time="hourly" ; fi
-   if [ "$min" = "0,30" ] ; then time="30min" ; fi
-   if [ "$min" = '*/10' ] ; then time="10min" ; fi
-   if [ "$min" = '*/5' ] ; then time="5min" ; fi
-   if [ "$min" = '*/5' -a "$count" = "auto" ] ; then time="Automatic" ; fi
-   echo "$i - $time - total: $count"
-   echo ""
-done
+if [ -z "$1" ]; then
+    list_cron_snap
+    list_cron_scrub
+    exit 0
+fi
 
-echo "Pools scheduled for scrub:"
-echo "---------------------------------"
-for i in `grep "${PROGDIR}/backend/runscrub.sh" /etc/crontab | awk '{print $8}'`
-do
-   hour=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $2}'`
-   day_week=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $5}'`
-   day_month=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $3}'`
-   if [ "$hour" != '*' -a "$day_week" = '*' -a "$day_month" = '*' ] ; then time="daily @ hour $hour" ; fi
-   if [ "$day_week" != '*' ] ; then time="weekly @ day $day_week @ hour $hour" ; fi
-   if [ "$day_month" != '*' ] ; then time="monthly @ day $day_month @ hour $hour" ; fi
-   echo "$i - $time"
-done
+if [ "$1" == "snap" ]; then
+    list_cron_snap
+    exit 0
+fi
 
+if [ "$1" == "scrub" ]; then
+    list_cron_scrub
+    exit 0
+fi

--- a/src-sh/lpreserver/lpreserver
+++ b/src-sh/lpreserver/lpreserver
@@ -283,7 +283,19 @@ List scheduled cron snapshots and scrubs
 
 Usage:
 
-  lpreserver listcron
+  lpreserver listcron <scrub|snap>
+
+Exmaple:
+
+  lpreserver listcron snap
+
+  or
+
+  lpreserver listcron scrub
+  
+  (NOTE: Empty argument list shows both scheduled snapshots
+  and scrubs.)
+
 "
 };
 
@@ -577,10 +589,18 @@ case "$1" in
          ${PROGDIR}/backend/zfsmksnap.sh "${DATASET}" "$SNAPNAME" "$COMMENT"
          ;;
 
- listcron) require_root
-         ${PROGDIR}/backend/zfslistcron.sh 
+ listcron) 
+	 if [ -z "$2" ]; then
+             ${PROGDIR}/backend/zfslistcron.sh
+	     exit 0
+         fi
+         case ${2} in
+             snap) ${PROGDIR}/backend/zfslistcron.sh snap;;
+             scrub) ${PROGDIR}/backend/zfslistcron.sh scrub;;
+	     *) help_listcron;;
+	 esac
          ;;
-
+        
  listsnap) require_root
          DATASET="$2"
          ${PROGDIR}/backend/zfslistsnap.sh "${DATASET}"


### PR DESCRIPTION
'lpreserver listcron' shows both scheduled scrubs and snapshots per default, but one can now split it up into only showing one or the other with 'lpreserver listcron snap|scrub'

This should help fix the lpreserver gui with minimal effort.
