### PR TITLE
VirtualBox doesn't need to run as root anymore, play better with BE's

### DIFF
--- a/src-sh/pcbsd-utils/pc-extractoverlay/ports-overlay/usr/local/share/applications/virtualbox.desktop
+++ b/src-sh/pcbsd-utils/pc-extractoverlay/ports-overlay/usr/local/share/applications/virtualbox.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Version=1.0
 Type=Application
-Exec=pc-su VirtualBox
+Exec=VirtualBox
 TryExec=VirtualBox
 Icon=VBox
 Categories=Emulator;System;


### PR DESCRIPTION
Tested bridged mode networking, cd passthrough, and all still works.  Making this change would allow the user to move between boot environments yet retain consistent virtual machine data.  There will however be a negative impact as users who have previously set up VirtualBox VM's will still have them set up under the root user.  This will likely result in them seeing nothing the next time they start up VirtualBox.  After this change is made a migration of VM's to the users profile will likely be necessary.  Due to this I am proposing this change rather than committing.
