### PR TITLE
Updated Makefile to include sqlite3 in base

### DIFF
--- a/build-files/ports-overlay/misc/pcbsd-base/Makefile
+++ b/build-files/ports-overlay/misc/pcbsd-base/Makefile
@@ -124,7 +124,8 @@ RUN_DEPENDS=	pc-updategui:${PORTSDIR}/sysutils/pcbsd-utils-qt5 \
 		unrar:${PORTSDIR}/archivers/unrar \
 		p7zip:${PORTSDIR}/archivers/p7zip \
 		avahi-browse:${PORTSDIR}/net/avahi-app \
-		vagrant>=0:${PORTSDIR}/sysutils/vagrant
+		vagrant>=0:${PORTSDIR}/sysutils/vagrant \
+		sqlite3>=0:${PORTSDIR}/databases/sqlite3
 
 NO_BUILD=	yes
 


### PR DESCRIPTION
This is my attempt to update your Makefile for the PC-BSD base to include sqlite3 on line 128.
https://www.freshports.org/databases/sqlite3/

I hope I'm doing this correctly in github.
