### PR TITLE
Life preserver size fix

### DIFF
--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -741,7 +741,17 @@ add_zpool_disk() {
    esac
 
    zSize=`gpart show ${rDiskDev} | grep freebsd-zfs | cut -d "(" -f 2 | cut -d ")" -f 1`
-   
+   # adjust to integer sizes for gpart
+   case "$zSize" in
+       *T) zSizeNum=`echo $zSize | rev | cut -c 2- | rev`
+           zSize="`echo "$zSizeNum * 1000" | bc | awk -F\. '{print $1}'`G"
+           ;;
+       *G) zSizeNum=`echo $zSize | rev | cut -c 2- | rev`
+           zSize="`echo "$zSizeNum * 1000" | bc | awk -F\. '{print $1}'`M"
+           ;;
+       *) ;;
+   esac
+
    echo "Creating new partitions on $disk"
    if [ "$type" = "MBR" ] ; then
       # Create the new MBR layout

--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -712,13 +712,13 @@ add_zpool_disk() {
    if [ $? -eq 0 ] ; then
       # MBR
       type="MBR"
-      # Strip off the "a-z"
-      rDiskDev=`echo $mDisk | rev | cut -c 2- | rev`
+      # Strip off the "a-z" and potential extensions (like .eli)
+      rDiskDev=`echo $mDisk | awk -F\. '{print $1}' | rev | cut -c 2- | rev`
    else
       # GPT
       type="GPT"
-      # Strip off the "p[1-9]"
-      rDiskDev=`echo $mDisk | rev | cut -c 3- | rev`
+      # Strip off the "p[1-9]" and potential extensions (like .eli)
+      rDiskDev=`echo $mDisk | awk -F\. '{print $1}' | rev | cut -c 3- | rev`
    fi
 
    # Make sure this disk has a layout we can read

--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -727,7 +727,7 @@ add_zpool_disk() {
       exit_err "failed to get disk device layout $rDiskDev"
    fi
 
-   # Get the size of "freebsd-zfs & freebsd-swap"
+   # Get the size of "freebsd-swap"
    sSize=`gpart show ${rDiskDev} | grep freebsd-swap | cut -d "(" -f 2 | cut -d ")" -f 1`
    # adjust to integer sizes for gpart
    case "$sSize" in
@@ -739,7 +739,7 @@ add_zpool_disk() {
            ;;
        *) ;;
    esac
-
+   # Get the size of "freebsd-zfs"
    zSize=`gpart show ${rDiskDev} | grep freebsd-zfs | cut -d "(" -f 2 | cut -d ")" -f 1`
    # adjust to integer sizes for gpart
    case "$zSize" in

--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -729,6 +729,17 @@ add_zpool_disk() {
 
    # Get the size of "freebsd-zfs & freebsd-swap"
    sSize=`gpart show ${rDiskDev} | grep freebsd-swap | cut -d "(" -f 2 | cut -d ")" -f 1`
+   # adjust to integer sizes for gpart
+   case "$sSize" in
+       *T) sSizeNum=`echo $sSize | rev | cut -c 2- | rev`
+           sSize="`echo "$sSizeNum * 1000" | bc | awk -F\. '{print $1}'`G"
+           ;;
+       *G) sSizeNum=`echo $sSize | rev | cut -c 2- | rev`
+           sSize="`echo "$sSizeNum * 1000" | bc | awk -F\. '{print $1}'`M"
+           ;;
+       *) ;;
+   esac
+
    zSize=`gpart show ${rDiskDev} | grep freebsd-zfs | cut -d "(" -f 2 | cut -d ")" -f 1`
    
    echo "Creating new partitions on $disk"

--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -732,10 +732,10 @@ add_zpool_disk() {
    # adjust to integer sizes for gpart
    case "$sSize" in
        *T) sSizeNum=`echo $sSize | rev | cut -c 2- | rev`
-           sSize="`echo "$sSizeNum * 1000" | bc | awk -F\. '{print $1}'`G"
+           sSize="`echo "$sSizeNum * 1024" | bc | awk -F\. '{print $1}'`G"
            ;;
        *G) sSizeNum=`echo $sSize | rev | cut -c 2- | rev`
-           sSize="`echo "$sSizeNum * 1000" | bc | awk -F\. '{print $1}'`M"
+           sSize="`echo "$sSizeNum * 1024" | bc | awk -F\. '{print $1}'`M"
            ;;
        *) ;;
    esac
@@ -744,10 +744,10 @@ add_zpool_disk() {
    # adjust to integer sizes for gpart
    case "$zSize" in
        *T) zSizeNum=`echo $zSize | rev | cut -c 2- | rev`
-           zSize="`echo "$zSizeNum * 1000" | bc | awk -F\. '{print $1}'`G"
+           zSize="`echo "$zSizeNum * 1024" | bc | awk -F\. '{print $1}'`G"
            ;;
        *G) zSizeNum=`echo $zSize | rev | cut -c 2- | rev`
-           zSize="`echo "$zSizeNum * 1000" | bc | awk -F\. '{print $1}'`M"
+           zSize="`echo "$zSizeNum * 1024" | bc | awk -F\. '{print $1}'`M"
            ;;
        *) ;;
    esac


### PR DESCRIPTION
Hi PCBSD-team,

i made lifepreserver to be more tolerant to disk sizes. Gpart apparently (has?) had a problem with disk sizes given as floats. My patches convert the sizes to integers specified in the next lower order of magnitude and make things work (again).

Cheers,
tpltnt 