### PR TITLE
life-preserver scrub scheduling in GUI and Wizard

### DIFF
--- a/src-qt5/life-preserver/lp-gui/LPBackend.h
+++ b/src-qt5/life-preserver/lp-gui/LPBackend.h
@@ -18,6 +18,7 @@ public:
 	static QStringList listDatasetSubsets(QString dataset); //list all subsets of the main dataset
 	static QStringList listSnapshots(QString dsmountpoint); //list all snapshots for a particular dataset mountpoint
 	static QStringList listLPSnapshots(QString dataset, QStringList &comments); //list all snapshots created by life preserver
+	static QStringList listScrubs(); //list all datasets with scrubs scheduled
 	static QStringList listReplicationTargets(); //list all datasets with replication enabled
 	static QStringList listCurrentStatus(); //list the current snapshot/replication status
 	//Dataset Management
@@ -28,6 +29,10 @@ public:
 	static void newSnapshot(QString dataset, QString snapshotname, QString snapshotcomment = "");
 	static bool removeSnapshot(QString dataset, QString snapshot);
 	static bool revertSnapshot(QString dataset, QString snapshot); //revert to given snapshot
+	// Scrub Management
+	static bool setupScrub(QString dataset, int time, int day, QString schedule); //get current settings for scrub
+	static bool removeScrub(QString dataset);
+	static bool scrubInfo(QString dataset, int& time, int& day, QString& schedule); //get current settings for scrub
 	//Replication Management
 	static bool setupReplication(QString dataset, QString remotehost, QString user, int port, QString remotedataset, int time);
 	static bool removeReplication(QString dataset, QString remotehost);

--- a/src-qt5/life-preserver/lp-gui/LPConfig.h
+++ b/src-qt5/life-preserver/lp-gui/LPConfig.h
@@ -20,16 +20,16 @@ public:
 	LPConfig(QWidget* parent = 0);
 	~LPConfig();
 
-	void loadDataset(QString, bool);
+	void loadDataset(QString, bool, bool);
 
 	//Output variables
-	bool localChanged, remoteChanged, isReplicated;
-	int localSchedule, localSnapshots, remotePort, remoteFreq;
-	QString remoteHost, remoteUser, remoteDataset;
+	bool localChanged, scrubChanged, remoteChanged, isReplicated, isScrubSched;
+	int localSchedule, localSnapshots, remotePort, remoteFreq, scrubTime, scrubDay;
+	QString remoteHost, remoteUser, remoteDataset, scrubSchedule;
 
 private:
 	Ui::LPConfig *ui;
-	void loadDatasetConfiguration(QString, bool);
+	void loadDatasetConfiguration(QString, bool, bool);
 	void checkForChanges();
 	void setLocalKeepNumber();
 
@@ -37,6 +37,7 @@ private slots:
 	void slotApplyChanges();
 	void slotCancelConfig();
 	void on_combo_local_schedule_currentIndexChanged(int);
+	void on_combo_scrub_schedule_currentIndexChanged(int);
 	void on_combo_remote_schedule_currentIndexChanged(int index);
 	void autoDetectReplicationTargets();
 };

--- a/src-qt5/life-preserver/lp-gui/LPConfig.ui
+++ b/src-qt5/life-preserver/lp-gui/LPConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>372</width>
-    <height>357</height>
+    <height>385</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="font">
@@ -41,15 +44,21 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_local">
       <attribute name="title">
        <string>Local Snapshots</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_2">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <item row="0" column="0">
         <widget class="QLabel" name="label_3">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="font">
           <font>
            <weight>75</weight>
@@ -61,10 +70,26 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_local_keep">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Keep:</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QComboBox" name="combo_local_schedule">
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
            <item>
             <property name="text">
              <string>Automatic</string>
@@ -147,19 +172,6 @@
           </widget>
          </item>
         </layout>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_local_keep">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Keep:</string>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -415,6 +427,197 @@
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab_scrub">
+      <attribute name="title">
+       <string>Scrub</string>
+      </attribute>
+      <widget class="QGroupBox" name="groupScrub">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>331</width>
+         <height>121</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Enable scheduled scrub</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_11">
+          <item>
+           <widget class="QComboBox" name="combo_scrub_schedule">
+            <property name="editable">
+             <bool>false</bool>
+            </property>
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Daily</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Weekly</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Monthly</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_10">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Day of month</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Day of week</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string> Hour</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <widget class="QSpinBox" name="spin_scrub_day_month">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>28</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="combo_scrub_day_week">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="editable">
+             <bool>false</bool>
+            </property>
+            <item>
+             <property name="text">
+              <string>Mondays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tuesdays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Wednesdays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Thursdays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Fridays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Saturdays</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Sundays</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QTimeEdit" name="time_scrub">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="maximumTime">
+             <time>
+              <hour>23</hour>
+              <minute>0</minute>
+              <second>0</second>
+             </time>
+            </property>
+            <property name="minimumTime">
+             <time>
+              <hour>1</hour>
+              <minute>0</minute>
+              <second>0</second>
+             </time>
+            </property>
+            <property name="displayFormat">
+             <string>@ h AP</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/src-qt5/life-preserver/lp-gui/LPWizard.cpp
+++ b/src-qt5/life-preserver/lp-gui/LPWizard.cpp
@@ -51,6 +51,28 @@ void LPWizard::slotFinished(){
     else{ totalSnapshots = ui->spin_keepDays->value() * (1440/(-localTime)); } //convert to number of snapshots a day
   }
 
+  enableScrub = ui->groupScrub->isChecked();
+  if(enableScrub){
+    int scrubschint = ui->combo_scrub_schedule->currentIndex();
+    if(scrubschint == 0){
+      scrubSchedule = "daily";
+      scrubDay = 0;
+    }else if(scrubschint == 1){
+      scrubSchedule = "weekly";
+      if(ui->combo_scrub_day_week->currentIndex() == 0){ scrubDay = 1; }
+      else if(ui->combo_scrub_day_week->currentIndex() == 1){ scrubDay = 2; }
+      else if(ui->combo_scrub_day_week->currentIndex() == 2){ scrubDay = 3; }
+      else if(ui->combo_scrub_day_week->currentIndex() == 3){ scrubDay = 4; }
+      else if(ui->combo_scrub_day_week->currentIndex() == 4){ scrubDay = 5; }
+      else if(ui->combo_scrub_day_week->currentIndex() == 5){ scrubDay = 6; }
+      else{ scrubDay = 7; }
+    }else{
+      scrubSchedule = "monthly";
+      scrubDay = ui->spin_scrub_day_month->value();
+    }
+    scrubTime = ui->time_scrub->time().hour();
+  }
+
   //Now close the UI
   this->close();
 }
@@ -83,6 +105,17 @@ void LPWizard::scanNetwork(){
       break;
     }
   }
+}
+
+void LPWizard::on_combo_scrub_schedule_currentIndexChanged(int index){
+  //Adjust whether the day of week box is enabled
+  ui->combo_scrub_day_week->setEnabled( (index == 1) );
+  ui->combo_scrub_day_week->setDisabled( (index != 1) );
+  //Adjust whether the day of month box is enabled
+  ui->spin_scrub_day_month->setEnabled( (index == 2) );
+  ui->spin_scrub_day_month->setDisabled( (index != 2) );
+  // Always make time box enabled
+  ui->time_scrub->setEnabled(true);
 }
 
 void LPWizard::on_combo_remote_freq_currentIndexChanged(int index){

--- a/src-qt5/life-preserver/lp-gui/LPWizard.h
+++ b/src-qt5/life-preserver/lp-gui/LPWizard.h
@@ -23,9 +23,9 @@ public:
 	//Input dataset
 	void setDataset(QString);
 	//Output variables
-	bool cancelled, enableReplication;
-	int localTime, totalSnapshots, remotePort, remoteTime;
-	QString remoteHost, remoteUser, remoteDataset;
+	bool cancelled, enableReplication, enableScrub;
+	int localTime, totalSnapshots, remotePort, remoteTime, scrubTime, scrubDay;
+	QString remoteHost, remoteUser, remoteDataset, scrubSchedule;
 
 	virtual int nextId() const; //override the standard page order sometimes
 
@@ -37,6 +37,7 @@ private slots:
 	void slotCancelled();
 	void scanNetwork();
 	void on_combo_remote_freq_currentIndexChanged(int index);
+	void on_combo_scrub_schedule_currentIndexChanged(int index);
 };
 
 #endif

--- a/src-qt5/life-preserver/lp-gui/LPWizard.ui
+++ b/src-qt5/life-preserver/lp-gui/LPWizard.ui
@@ -669,6 +669,223 @@
     </item>
    </layout>
   </widget>
+  <widget class="QWizardPage" name="wizardPage_scrub">
+   <widget class="QGroupBox" name="groupBox_3">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>441</width>
+      <height>401</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Scrub schedule</string>
+    </property>
+    <widget class="QGroupBox" name="groupScrub">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>70</y>
+       <width>421</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Enable scheduled scrub</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QComboBox" name="combo_scrub_schedule">
+          <property name="editable">
+           <bool>false</bool>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>Daily</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Weekly</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Monthly</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Day of month</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Day of week</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string> Hour</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <widget class="QSpinBox" name="spin_scrub_day_month">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>28</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="combo_scrub_day_week">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="editable">
+           <bool>false</bool>
+          </property>
+          <item>
+           <property name="text">
+            <string>Mondays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Tuesdays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Wednesdays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Thursdays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Fridays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Saturdays</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Sundays</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTimeEdit" name="time_scrub">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="maximumTime">
+           <time>
+            <hour>23</hour>
+            <minute>0</minute>
+            <second>0</second>
+           </time>
+          </property>
+          <property name="minimumTime">
+           <time>
+            <hour>1</hour>
+            <minute>0</minute>
+            <second>0</second>
+           </time>
+          </property>
+          <property name="displayFormat">
+           <string>@ h AP</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QLabel" name="label_15">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>30</y>
+       <width>411</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Scrubbing checks for inconsistencies and silent corruption on your storage pool.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </widget>
+  </widget>
   <widget class="QWizardPage" name="wizardPage_finished">
    <layout class="QGridLayout" name="gridLayout_2">
     <item row="0" column="0">

--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -214,9 +214,9 @@ do
    hour=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $2}'`
    day_week=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $5}'`
    day_month=`grep "${PROGDIR}/backend/runscrub.sh ${i}" /etc/crontab | awk '{print $3}'`
-   if [ "$hour" != '*' -a "$day_week" = '*' -a "$day_month" = '*' ] ; then time="daily @ hour $hour" ; fi
-   if [ "$day_week" != '*' ] ; then time="weekly @ day $day_week @ hour $hour" ; fi
-   if [ "$day_month" != '*' ] ; then time="monthly @ day $day_month @ hour $hour" ; fi
+   if [ "$hour" != '*' -a "$day_week" = '*' -a "$day_month" = '*' ] ; then time="daily @ $hour" ; fi
+   if [ "$day_week" != '*' ] ; then time="weekly @ $day_week @ $hour" ; fi
+   if [ "$day_month" != '*' ] ; then time="monthly @ $day_month @ $hour" ; fi
    echo "$i - $time"
    echo ""
 done


### PR DESCRIPTION
This commit also fixes a bug where the datasets in the GUI were incorrectly detected.

There are two minor bugs that I'm not able to fix.

* In the wizard when enabling scrub schedule the boxes aren't updated until you change the schedule.
* In the configuration GUI the monthly day box is enabled when the scrub scheduling isn't.