### PR TITLE
Disk Manager - Added mount/unmount of foreign file systems

### DIFF
--- a/src-qt5/pc-zmanager/zmanagerwindow.h
+++ b/src-qt5/pc-zmanager/zmanagerwindow.h
@@ -36,6 +36,7 @@ struct __vdev_t {
     int Index;
     int Status;
     QString PartType;           // TYPE OF PARTITIONING SYSTEM OR PARTITION TYPE
+    QString FSType;             // TYPE OF FILE SYSTEM
     QString InPool;
     int SectorSize;
     unsigned long long SectorStart;


### PR DESCRIPTION
Previously, I had added support to create foreign partitions. Now I included the ability to mount and unmount those file systems (ext2, ext3, ext4, ntfs, fat32, fat16).
Notice that support for ntfs requires the package ntfs-3g (installed by default), and support for ext4 requires fusefs-ext4fuse (not sure if this is a default).
Support for ext4 is read-only in ext4fuse.
