### PR TITLE
Changed LPWatcher to set timers max only once during each polling loop

### DIFF
--- a/src-qt5/docs/README.md
+++ b/src-qt5/docs/README.md
@@ -75,13 +75,13 @@ sphinx-build -b epub . _build
 ##Editing the Documentation
 
 If you want to edit the User Guide, make changes to the \*.rst file for the chapter to edit, using any ASCII text editor.
-Refer to the `DocUtils Quick Reference Guide <http://docutils.sourceforge.net/docs/user/rst/quickref.html/>`_ for help with formatting syntax.
-Also refer to `this list of reST editors <http://wiki.typo3.org/Editors_%28reST%29/>`_.
+Refer to the [Quick reStructuredText guide](http://docutils.sourceforge.net/docs/user/rst/quickref.html) for help with formatting syntax.
+Also refer to this [list of reST editors](http://wiki.typo3.org/Editors_%28reST%29).
 
-Some very helpful tools for editing the documentation are listed below by editor:
+Some very helpful tools for editing the documentation are listed below by editor.
 
-`Vim <http://www.vim.org>`_::
-* `vim-rst-tables <https://github.com/nvie/vim-rst-tables>`_ will help you create and reformat grid tables
+[Vim](http://www.vim.org):
+* [vim-rst-tables](https://github.com/nvie/vim-rst-tables) will help you create and reformat grid tables
 
 Need help getting started or want to discuss edits? Join the http://lists.pcbsd.org/mailman/listinfo/docs mailing list.
 

--- a/src-qt5/life-preserver/lp-tray/LPWatcher.cpp
+++ b/src-qt5/life-preserver/lp-tray/LPWatcher.cpp
@@ -594,8 +594,7 @@ void LPWatcher::checkPoolStatus(){
 	  cDev << device;
 	}
       }
-      // Once all status has been processed, we can "safely"
-      // set another timer. -1 represents the condition that no timer was set.
+      // Once all status has been processed, we can "safely" set another timer.
       if((nextPoll < disabledTime) && (timer->interval() != nextPoll)) { timer->start(nextPoll); }
     } //end of loop over zpool status lines
     


### PR DESCRIPTION
This helps prevent the condition where the function can hang after parsing partial input from an external command. Hopefully, this will eliminate an observed race condition resulting in pc-systemupdatertray taking ~100% cpu.