### PR TITLE
Remove illegal SSL option for stunnel

### DIFF
--- a/src-sh/lpreserver/backend/functions.sh
+++ b/src-sh/lpreserver/backend/functions.sh
@@ -671,7 +671,6 @@ connect_iscsi() {
      # Create the config
      echo "client = yes
 foreground = yes
-options = NO_SSLv2
 [iscsi]
 accept=127.0.0.1:3260
 connect = $REPHOST:$REPPORT" > ${STCFG}

--- a/src-sh/lpreserver/lpreserver-host-iscsi
+++ b/src-sh/lpreserver/lpreserver-host-iscsi
@@ -178,7 +178,6 @@ if [ ! -e "/usr/local/etc/stunnel/stunnel.conf" ] ; then
   cat >/usr/local/etc/stunnel/stunnel.conf << EOF
 setuid = stunnel
 setgid = nogroup
-options = NO_SSLv2
 client = no
 
 [iscsi]


### PR DESCRIPTION
Running stunnel with options = NO_SSLv2 give the following error message on 11.0-CURRENTDEC2015, stunnel ver 5.26:

options = NO_SSLv2 : Illegal SSL option

That option isn't necessary anyway since it was disabled by default since version 5.06.