### PR TITLE
Consistency use of terminology in the docs

### DIFF
--- a/src-sh/lpreserver/lpreserver
+++ b/src-sh/lpreserver/lpreserver
@@ -50,7 +50,7 @@ Type in help <command> for information and usage about that command
    listcron - Listing of scheduled snapshots and scrubs
    listsnap - List snapshots of a zpool/dataset
      mksnap - Create a ZFS snapshot of a zpool/dataset
-  replicate - Sub-command of replication tasks
+  replicate - Manage replication tasks
  revertsnap - Revert zpool/dataset to a snapshot
      rmsnap - Remove a snapshot
         set - Set lpreserver options
@@ -64,9 +64,9 @@ help_zpool()
  title
  echo "Help zpool
 
-Life-Preserver zpool sub-system
+Life-Preserver zpool subsystem
 
-The 'zpool' sub-command allows you to attach / detach drives to a zpool, 
+The 'zpool' subcommand allows you to attach / detach drives to a zpool, 
 as well as get status and more. 
 
 When a drive is first attached to a zpool, it will be re-formatted with
@@ -122,7 +122,7 @@ List Options:
 
 Usage:
 
-  lpreserver zpool <subcmd> <flags>
+  lpreserver zpool <subcommand> <options>
 
 Example:
 
@@ -135,7 +135,7 @@ help_replicate()
  title
  echo "Help replicate
 
-Life-Preserver replication sub-system
+Manege Life-Preserver replication tasks
 
 Replication uses ZFS to send your snapshots to a remote system which also has
 a ZFS pool, such as FreeNAS or another PC-BSD system. The <hostdataset> must
@@ -152,10 +152,10 @@ permissions on the remote dataset:
 
 Usage:
 
-  lpreserver replicate <subcmd> <flags>
+  lpreserver replicate <subcommand> <Options>
 
 
-Available Flags:
+Available subcommands:
 
          add - Add a new replication target
       expand - Expand the remote iSCSI zpool

--- a/src-sh/lpreserver/lpreserver.8
+++ b/src-sh/lpreserver/lpreserver.8
@@ -6,7 +6,7 @@
 .Nd "Life Preserver"
 .Sh SYNOPSIS
 .Nm
-.Op  "<cmd> <subcmd> <option> <setting>"
+.Op  "<cmd> <subcommand> <option> <setting>"
 .Sh DESCRIPTION
 The built-in Life Preserver utility was designed to take full advantage of ZFS snapshot functionality. This utility allows you to schedule snapshots of a local ZFS pool and to optionally replicate those snapshots to another system using SSH
 .Bl -tag indent -width
@@ -51,10 +51,10 @@ List of scheduled snapshots and scrubs not using scrub or snap results in both b
 List snapshots that are part of <dataset> zpool or data set.
 .It \fBmksnap <dataset> <snapshotname> <comment>\fR
 Create a snapshot of a zpool or data set.
-.It \fBreplicate <subcmd> <flags>\fR
-Sub command of replication tasks
+.It \fBreplicate <subcommand> <options>\fR
+Manage replication tasks
 .br
-Available sub commands are
+Available subcommands are
 .br
     add - Add a new replication target
 .br
@@ -95,7 +95,7 @@ Available sub commands are
 Revert zpool or data set to a snapshot
 .It \fBrmsnap <dataset> <snapshot>\fR
 Remove a snapshot
-.It \fBset <subcmd> <setting>\fR
+.It \fBset <subcommand> <setting>\fR
 Set lpreserver options
 .br
      duwarn <percentage>- Set to a disk 
@@ -122,7 +122,7 @@ List data sets along with last snapshot and replication data
 .It \fBzpool\fR
 Manage a zpool by attaching and detaching disks
 .br
-Available sub commands
+Available subcommands
 .br
 	list <zpool>- List zpool disks
 .br


### PR DESCRIPTION
There was some inconsistency between subcommands, flags, and options in
the documentation. Fix these up so that subcommands use options.

Reworded replication subsystem a bit to be consistent docs for other
commands.

Also dropped the hyphens for "sub", it's not really needed.

This was confusing me, so I tried to fix it up.

I also tried to fix the new manpage, but I didn't know how to compile that, so you MAY want to check that first.