### PR TITLE
Force xstartup/gpg-agent.sh output to sh format

### DIFF
--- a/src-qt5/xtrafiles/local/share/pcbsd/xstartup/gpg-agent.sh
+++ b/src-qt5/xtrafiles/local/share/pcbsd/xstartup/gpg-agent.sh
@@ -13,7 +13,7 @@ if [ $UID -gt 1000 ]; then
     gpg_options=
     [ -d "${HOME}/.ssh" ] && gpg_options=--enable-ssh-support
     if [ -x "${GPG_AGENT}" ] && [ -z $(pgrep -u "${UID}" gpg-agent) ]; then
-      $GPG_AGENT --daemon ${gpg_options} --log-file "${HOME}/.gnupg/gpg-agent.log" > "${HOME}/.gpg-agent-info"
+      $GPG_AGENT -s --daemon ${gpg_options} --log-file "${HOME}/.gnupg/gpg-agent.log" > "${HOME}/.gpg-agent-info"
       . "${HOME}/.gpg-agent-info"
     elif [ ! -z $(pgrep -u $UID gpg-agent) ] && [ -f "${HOME}/.gpg-agent-info" ]; then
       . "${HOME}/.gpg-agent-info"


### PR DESCRIPTION
By default [gpg-agent(1)][] generates output based on the environment
variable `SHELL`.

[gpg-agent(1)]: https://www.freebsd.org/cgi/man.cgi?query=gpg-agent&manpath=FreeBSD+10.2-RELEASE+and+Ports

If the user uses a _csh_ derivative the resulting `${HOME}/.gpg-agent-info`
has no effect when sourced later in the `xstartup/gpg-agent.sh` script.

This is made quite evident when trying to forward the SSH agent authentication. An example session showing the problem follows:

```
[itorres@magellan] ~% cat .gpg-agent-info 
setenv SSH_AUTH_SOCK /usr/home/itorres/.gnupg/S.gpg-agent.ssh;
[itorres@magellan] ~% echo $SHELL
/bin/csh
[itorres@magellan] ~% 
[itorres@magellan] ~% ps -x | grep gpg
74555  -  Ss      0:00,03 /usr/local/bin/gpg-agent --daemon --enable-ssh-support --log-file /usr/home/itorres/.gnupg/gpg-agent.log
[itorres@magellan] ~% env | grep SSH
[itorres@magellan] ~%
[itorres@magellan] ~% ssh -A 192.168.1.14
Last login: Mon Mar 21 18:37:32 2016 from euclid.hq.xin.cat
FreeBSD 11.0-CURRENTMAR2016 (GENERIC) #0 e0cb0b6(freebsd-base-graphics): Sat Feb 27 01:01:50 UTC 2016
[itorres@venera14 ~]$
[itorres@venera14 ~]$ ssh root@192.168.1.13
Password:^C
[itorres@venera14 ~]$ logout
[itorres@magellan] ~% source .gpg-agent-info 
[itorres@magellan] ~% env | grep SSH
SSH_AUTH_SOCK=/usr/home/itorres/.gnupg/S.gpg-agent.ssh
[itorres@magellan] ~% ssh -A 192.168.1.14
Last login: Mon Mar 21 18:37:32 2016 from euclid.hq.xin.cat
FreeBSD 11.0-CURRENTMAR2016 (GENERIC) #0 e0cb0b6(freebsd-base-graphics): Sat Feb 27 01:01:50 UTC 2016
[itorres@venera14 ~]$
[itorres@venera14 ~]$ ssh root@192.168.1.13
- SmartOS Live Image v0.147+ build: 20160304T005100Z
You have new mail.
[root@venera13 ~]#
```