### PR TITLE
reboot prompt time options

### DIFF
--- a/src-qt5/pc-systemupdatertray/dialogReminder.h
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.h
@@ -35,7 +35,7 @@ private slots:
 		minutes = 60; //1 hour
 	        break;
 	    case 3:
-		minutes = 300; //5 hours
+		minutes = 240; //4 hours
 	        break;
 	    case 4:
 		minutes = 720; //12 hours

--- a/src-qt5/pc-systemupdatertray/dialogReminder.h
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.h
@@ -37,13 +37,13 @@ private slots:
 	    case 3:
 		minutes = 240; //4 hours
 	        break;
-	    case :
+	    case 4:
 	        minutes = 480; //8 hours
 	        break;
-	    case 4:
+	    case 5:
 		minutes = 720; //12 hours
 	        break;
-	    case 5:
+	    case 6:
 		minutes = 1440; //24 hours
 	        break;
 	    default:

--- a/src-qt5/pc-systemupdatertray/dialogReminder.h
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.h
@@ -37,6 +37,9 @@ private slots:
 	    case 3:
 		minutes = 240; //4 hours
 	        break;
+	    case :
+	        minutes = 480; //8 hours
+	        break;
 	    case 4:
 		minutes = 720; //12 hours
 	        break;

--- a/src-qt5/pc-systemupdatertray/dialogReminder.ui
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.ui
@@ -141,7 +141,7 @@ border-radius: 5px;
      </item>
      <item>
       <property name="text">
-       <string>8 Hour</string>
+       <string>8 Hours</string>
       </property>
      </item>
      <item>

--- a/src-qt5/pc-systemupdatertray/dialogReminder.ui
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.ui
@@ -136,7 +136,7 @@ border-radius: 5px;
      </item>
      <item>
       <property name="text">
-       <string>5 Hours</string>
+       <string>4 Hours</string>
       </property>
      </item>
      <item>

--- a/src-qt5/pc-systemupdatertray/dialogReminder.ui
+++ b/src-qt5/pc-systemupdatertray/dialogReminder.ui
@@ -141,6 +141,11 @@ border-radius: 5px;
      </item>
      <item>
       <property name="text">
+       <string>8 Hour</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>12 Hours</string>
       </property>
      </item>


### PR DESCRIPTION
Saw the following request in #pcbsd:

> "Could somebody add more choices "systems needs to be rebooted" prompt?  I usually see this window at the start of the working day, and it has no '8 hours'. :)"


Noticed that the time slots were 30 minutes, 1h, 5h, 12h, 24h.  The jump to 1 to 5 to 12 seemed odd, so I altered options to 1, 4, 8, 12 as it seemed more practical and even.



