### PR TITLE
Prevent the update process from hanging if a NFS/CIFS server goes away

### DIFF
--- a/src-sh/pcbsd-utils/pc-updatemanager/pc-updatemanager
+++ b/src-sh/pcbsd-utils/pc-updatemanager/pc-updatemanager
@@ -1812,6 +1812,10 @@ shutdown_update() {
     FKEY=""
   fi
 
+  # Unmount remote filesystems to prevent the update process from
+  # hanging if the remote server goes down.
+  umount -A -t nfs,smbfs,cifs
+
   # Display whats going on:
   echo "*****************************************************"
   echo "             Starting update process..."


### PR DESCRIPTION
This patch fixes a problem I saw where my PC-BSD desktop would hang forever during the update process. I typically power off all my equipment when not in use, so when I powered off the NFS server while the pc-updatemanager process was running, it caused the update process to hang.