### PR TITLE
Minor updates to the Disk Manager

### DIFF
--- a/src-qt5/pc-zmanager/zmanagerwindow.h
+++ b/src-qt5/pc-zmanager/zmanagerwindow.h
@@ -250,6 +250,7 @@ private slots:
     void on_fspoolList_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
 
 
+    void on_refreshButton_clicked();
 };
 
 

--- a/src-qt5/pc-zmanager/zmanagerwindow.ui
+++ b/src-qt5/pc-zmanager/zmanagerwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>589</width>
-    <height>493</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,10 +19,10 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout_4">
-    <item row="0" column="0">
+    <item row="2" column="1">
      <widget class="QTabWidget" name="tabContainer">
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <property name="iconSize">
        <size>
@@ -294,6 +294,19 @@
       </widget>
      </widget>
     </item>
+    <item row="5" column="1">
+     <widget class="QPushButton" name="refreshButton">
+      <property name="focusPolicy">
+       <enum>Qt::TabFocus</enum>
+      </property>
+      <property name="text">
+       <string>Refresh</string>
+      </property>
+      <property name="icon">
+       <iconset theme="reload"/>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menuBar">
@@ -302,7 +315,7 @@
      <x>0</x>
      <y>0</y>
      <width>589</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
I noticed some things weren't working properly in the Disk Manager so I made a few updates:
* Use file instead of blkid, this improves file system detection (at a speed penalty...).
* Old partitions msdos are now called fat16, fat32, ntfs, so it's detection routines had to be adjusted accordingly.
* Added a refresh button, since the Disk Manager does not automatically refresh when a disk is inserted, this was annoying.

NOTE: Disk Manager needs package e2fsprogs in order to create ext2/3 file systems, and fusefs-ext4 for ext4.
